### PR TITLE
Transparent and animation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ export default class AwesomeProject extends Component {
 | backdropStyle   | object    | null            | To style the overlay                             |
 | textStyle       | object    | null            | To style the text shown in the box               |
 | optionListStyle | object    | null            | To style the selection box                       |
+| transparent     | boolean   | false           | To set the transparent prop on Modal             |
+| animationType   | string    | "none"          | To set the animationType prop on Modal           |
 
 
 ### Props for Option

--- a/lib/select.js
+++ b/lib/select.js
@@ -18,7 +18,7 @@ const window = Dimensions.get('window');
 class Select extends Component {
 	constructor(props) {
 	  super(props);
-	
+
 	  this.state = {modalVisible : false, defaultText : this.props.defaultText};
 	}
 
@@ -34,7 +34,7 @@ class Select extends Component {
 
 	render() {
 		let {style, defaultText, textStyle, backdropStyle,
-			optionListStyle} = this.props;
+			optionListStyle, transparent, animationType} = this.props;
 
 		return (
 			<View style = {[styles.selectBox, style]}>
@@ -48,23 +48,24 @@ class Select extends Component {
 				</TouchableWithoutFeedback>
 
 				<Modal
-		          transparent={false}
+							transparent={transparent}
+							animationType={animationType}
 		          visible={this.state.modalVisible}
 		          >
-				
-				 <TouchableWithoutFeedback 
-				 	
+
+				 <TouchableWithoutFeedback
+
 				 	onPress ={this.onModalPress.bind(this)}>
-					
+
 					<View style={[styles.modalOverlay, backdropStyle]}>
 			         	<OptionList onSelect = {this.onSelect.bind(this)}
 			         		style = {[optionListStyle]}>
 							 {this.props.children}
-						</OptionList>				
+						</OptionList>
 			        </View>
 				 </TouchableWithoutFeedback>
-		          
-		        </Modal> 
+
+		        </Modal>
 			</View>
 		);
 	}
@@ -82,9 +83,9 @@ class Select extends Component {
 	 Fires when user clicks on modal. primarily used to close
 	 the select box
 	 */
-	
+
 	onModalPress() {
-	
+
 		this.setState({
 			...this.state,
 			modalVisible : false
@@ -120,6 +121,8 @@ Select.propTypes = {
 
 Select.defaultProps = {
   defaultText : "Click To Select",
-  onSelect  : () => {}
+  onSelect  : () => {},
+	transparent : false,
+	animationType : "none"
 }
 export default Select;


### PR DESCRIPTION
Added `transparent` and `animationType` props to `Select` component that are passed onto the`Modal` component.

This allows Nice transparent or opaque modal background with 
```
<Select
    ...
    backdropStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.85)' }}
    transparent={true}
    animationType="fade"
>
```

Example -
![screen shot 2017-01-06 at 15 56 53](https://cloud.githubusercontent.com/assets/6524830/21723800/b57085d2-d429-11e6-9cff-15255ecda343.png)
