### PR TITLE
Add an optional indicator arrow to Select

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # React Native Chooser
-Simple DropDown menu for React Native App! Your Select Tag for React Native. Fully Customizable too. 
+Simple DropDown menu for React Native App! Your Select Tag for React Native. Fully Customizable too.
 
 ## Introduction
 
-React Native Chooser is simple, customizable and easy to use dropdown in React Native. It has been tested on both Android and IOS and works like a charm. 
+React Native Chooser is simple, customizable and easy to use dropdown in React Native. It has been tested on both Android and IOS and works like a charm.
 
 ## Installation
 ```
@@ -35,7 +35,7 @@ export default class AwesomeProject extends Component {
     return (
       <View style={styles.container}>
         <Select
-            onSelect = {this.onSelect.bind(this)} 
+            onSelect = {this.onSelect.bind(this)}
             defaultText  = "Select Me Please"
             style = {{borderWidth : 1, borderColor : "green"}}
             textStyle = {{}}
@@ -61,7 +61,7 @@ export default class AwesomeProject extends Component {
 ```
 
 
-### Props 
+### Props
 
 ### Props for Select
 
@@ -75,6 +75,10 @@ export default class AwesomeProject extends Component {
 | optionListStyle | object    | null            | To style the selection box                       |
 | transparent     | boolean   | false           | To set the transparent prop on Modal             |
 | animationType   | string    | "none"          | To set the animationType prop on Modal           |
+| indicator       | string "none", "up" or "down" | "none" | To enable an indicator arrow          |
+| indicatorColor  | string    | "black"         | The color of the indicator arrow                 |
+| indicatorSize   | number    | 10              | The size of the indicator arrow                  |
+| indicatorStyle  | object    | null            | To style the indicator arrow                     |
 
 
 ### Props for Option
@@ -95,4 +99,3 @@ export default class AwesomeProject extends Component {
 
 ## Contributions
 Your contributions and suggestions are heartily♡ welcome. (✿◠‿◠)
-

--- a/lib/indicator.js
+++ b/lib/indicator.js
@@ -1,0 +1,64 @@
+import React 	          from "react";
+import ReactNative  		from "react-native";
+
+var {
+	View,
+	Text,
+	StyleSheet,
+	TouchableWithoutFeedback,
+	Modal,
+	Dimensions
+} = ReactNative;
+
+const Indicator = function({
+  direction,
+  size,
+  color,
+  style
+}) {
+  const styles = getStyles(size, color)
+
+  if (direction === 'up') {
+    return (
+      <View style={[styles.triangle, style]} />
+    );
+  }
+  else if (direction === 'down') {
+    return (
+      <View style={[styles.triangle, styles.triangleDown, style]} />
+    );
+  }
+
+  return null
+}
+
+const getStyles = function(size, color) {
+  return StyleSheet.create({
+    triangle: {
+      width: 0,
+      height: 0,
+      backgroundColor: 'transparent',
+      borderStyle: 'solid',
+      borderLeftWidth: size / 2,
+      borderRightWidth: size / 2,
+      borderBottomWidth: size,
+      borderLeftColor: 'transparent',
+      borderRightColor: 'transparent',
+      borderBottomColor: color
+    },
+    triangleDown: {
+      transform: [
+        {rotate: '180deg'}
+      ]
+    }
+  });
+}
+
+Indicator.propTypes = {
+  direction : React.PropTypes.string,
+  size : React.PropTypes.number.isRequired,
+  color : React.PropTypes.string.isRequired,
+	style : View.propTypes.style
+}
+
+export default Indicator;

--- a/lib/select.js
+++ b/lib/select.js
@@ -1,6 +1,7 @@
 import React, {Component} 	from "react";
 import ReactNative  		from "react-native";
 import OptionList    		from "./optionlist";
+import Indicator    		from "./indicator";
 
 var {
 	View,
@@ -34,16 +35,18 @@ class Select extends Component {
 
 	render() {
 		let {style, defaultText, textStyle, backdropStyle,
-			optionListStyle, transparent, animationType} = this.props;
+			optionListStyle, transparent, animationType,
+			indicator, indicatorColor, indicatorSize, indicatorStyle} = this.props;
 
 		return (
 			<View style = {[styles.selectBox, style]}>
 
-				<TouchableWithoutFeedback
+			<TouchableWithoutFeedback
 					onPress = {this.onPress.bind(this)}
 					>
-					<View>
-						<Text style = {[textStyle]}>{this.state.defaultText}</Text>
+					<View style={styles.selectBoxContent}>
+						<Text style = {textStyle}>{this.state.defaultText}</Text>
+						<Indicator direction={indicator} color={indicatorColor} size={indicatorSize} style={indicatorStyle} />
 					</View>
 				</TouchableWithoutFeedback>
 
@@ -100,6 +103,11 @@ var styles = StyleSheet.create({
 		padding : 10,
 		borderColor : "black"
 	},
+	selectBoxContent: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+	},
 	modalOverlay : {
 		flex : 1,
 		justifyContent : "center",
@@ -116,13 +124,20 @@ Select.propTypes = {
 	onSelect : React.PropTypes.func,
 	textStyle : Text.propTypes.style,
 	backdropStyle : View.propTypes.style,
-	optionListStyle : View.propTypes.style
+	optionListStyle : View.propTypes.style,
+	indicator : React.PropTypes.string,
+	indicatorColor : React.PropTypes.string,
+	indicatorSize : React.PropTypes.number,
+	indicatorStyle : View.propTypes.style
 }
 
 Select.defaultProps = {
   defaultText : "Click To Select",
   onSelect  : () => {},
 	transparent : false,
-	animationType : "none"
+	animationType : "none",
+	indicator : "none",
+	indicatorColor: "black",
+	indicatorSize: 10
 }
 export default Select;


### PR DESCRIPTION
You can now opt-in to show an indicator arrow (either pointing up or down) on the select box with `indicator="up|down"`

You can also set the color and size, and also supply your own styles if required.

This allows the following to be easily created

![screen shot 2017-01-09 at 14 07 14](https://cloud.githubusercontent.com/assets/6524830/21769672/cf8a0b6e-d677-11e6-9a4c-4659374417cc.png)
