### PR TITLE
Add onRequestClose to Modal to better support Android

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -31,6 +31,12 @@ class Select extends Component {
 		});
 	}
 
+	onRequestClose() {
+		this.setState({
+			...this.state,
+			modalVisible : false,
+		});
+	}
 
 	render() {
 		let {style, defaultText, textStyle, backdropStyle,
@@ -51,6 +57,7 @@ class Select extends Component {
 							transparent={transparent}
 							animationType={animationType}
 		          visible={this.state.modalVisible}
+							onRequestClose={this.onRequestClose.bind(this)}
 		          >
 
 				 <TouchableWithoutFeedback


### PR DESCRIPTION
Adds the required (for android) `onRequestClose` prop to `Modal` to handle back button presses.
