### PR TITLE
Allow options to take in object and string

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -12,9 +12,9 @@ export default class Option extends Component {
 		style: View.propTypes.style,
 		styleText: Text.propTypes.style,
 		children: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.string
-    ]).isRequired
+      			React.PropTypes.object,
+      			React.PropTypes.string
+    		]).isRequired
 	};
 
 	render() {

--- a/lib/option.js
+++ b/lib/option.js
@@ -11,7 +11,10 @@ export default class Option extends Component {
 	static propTypes = {
 		style: View.propTypes.style,
 		styleText: Text.propTypes.style,
-		children: React.PropTypes.string.isRequired
+		children: React.PropTypes.oneOfType([
+      React.PropTypes.object,
+      React.PropTypes.string
+    ]).isRequired
 	};
 
 	render() {

--- a/lib/optionlist.js
+++ b/lib/optionlist.js
@@ -30,9 +30,9 @@ export default class OptionList extends Component {
 				<ScrollView
 					automaticallyAdjustContentInsets={false}
 					bounces={false} >
-				 {renderedItems}				
+				 {renderedItems}
 				</ScrollView>
-			</View>	
+			</View>
 		)
 	}
 }


### PR DESCRIPTION
Currently options allow only string type as it children. I want to show some icons with text in each options as below:
```
<Option value = "General">
  <View>
    <Icon name='user' size={25} color={'#555555'} style={{padding: 5}} /> General
  </View>
</Option>
```