### PR TITLE
Make entire tag selectable

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -69,39 +69,35 @@ export default class Select extends Component {
 			selectedStyle, selected} = this.props
 
 		return (
-			<View style = {[styles.selectBox, style]}>
-
-			<TouchableWithoutFeedback
-					onPress = {this.onPress.bind(this)}
-					>
-					<View style={styles.selectBoxContent}>
-						<Text style = {textStyle}>{this.state.defaultText}</Text>
-						<Indicator direction={indicator} color={indicatorColor} size={indicatorSize} style={indicatorStyle} />
+			<View>
+				<TouchableWithoutFeedback onPress = {this.onPress.bind(this)}>
+					<View style = {[styles.selectBox, style]}>
+						<View style={styles.selectBoxContent}>
+							<Text style = {textStyle}>{this.state.defaultText}</Text>
+							<Indicator direction={indicator} color={indicatorColor} size={indicatorSize} style={indicatorStyle} />
+						</View>
 					</View>
 				</TouchableWithoutFeedback>
 
 				<Modal
-							transparent={transparent}
-							animationType={animationType}
-		          visible={this.state.modalVisible}
-							onRequestClose={this.onClose.bind(this)}
-		          >
-
-				 <TouchableWithoutFeedback
-
-				 	onPress ={this.onModalPress.bind(this)}>
-
+					transparent={transparent}
+					animationType={animationType}
+					visible={this.state.modalVisible}
+					onRequestClose={this.onClose.bind(this)}
+			  	>
+				 <TouchableWithoutFeedback onPress ={this.onModalPress.bind(this)}>
 					<View style={[styles.modalOverlay, backdropStyle]}>
-			         	<OptionList onSelect = {this.onSelect.bind(this)}
-			         		selectedStyle = {selectedStyle}
-			         		selected = {selected}
-			         		style = {[optionListStyle]}>
-							 {this.props.children}
+						<OptionList
+							onSelect = {this.onSelect.bind(this)}
+							selectedStyle = {selectedStyle}
+							selected = {selected}
+							style = {[optionListStyle]}>
+							{this.props.children}
 						</OptionList>
-			        </View>
+					</View>
 				 </TouchableWithoutFeedback>
 
-		        </Modal>
+				</Modal>
 			</View>
 		)
 	}


### PR DESCRIPTION
Currently only the text and indicator button are selectable. This small change will make the entire tag selectable.