### PR TITLE
Change selected text when selected value changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,6 @@ export default class AwesomeProject extends Component {
 | selectedStyle   | object    | null            | Apply styles to the selected Option              |
 
 
-### Functions for Select
-
-
-| Function Name | Description |
-|-----------|-----------|
-| setSelectedText(text) | Set default text in the select option, often used to reset text.|
-
 ### Props for Option
 
 

--- a/lib/select.js
+++ b/lib/select.js
@@ -9,6 +9,7 @@ import {
 } from "react-native"
 
 import OptionList from "./optionlist"
+import Option from './option'
 import Indicator from "./indicator"
 
 const window = Dimensions.get('window')
@@ -40,26 +41,26 @@ export default class Select extends Component {
 
 	constructor(props) {
 	  super(props)
-	  this.selected = this.props.selected
 	  this.state = {
-	  	modalVisible : false, 
-		  defaultText : this.props.defaultText, 
-		  selected : this.props.selected,
+	  	modalVisible : false
 		}
 	}
-	
-	componentWillReceiveProps (nextProps) {
-		if (nextProps.selected == null)
-			this.setState({
-				defaultText: nextProps.defaultText
-			})
+
+	getSelectedText() {
+		if (this.props.selected) {
+			for (const child of this.props.children) {
+				if (child.type === Option && child.props.value === this.props.selected) {
+				  return child.props.children
+				}
+			}
+		}
+		return this.props.defaultText
 	}
-	
+
 	onSelect(label, value) {
 		this.props.onSelect(value)
 		this.setState({
-			modalVisible : false,
-			defaultText : label
+			modalVisible : false
 		})
 	}
 
@@ -70,17 +71,18 @@ export default class Select extends Component {
 	}
 
 	render() {
-		let {style, defaultText, textStyle, backdropStyle,
+		const {style, textStyle, backdropStyle,
 			optionListStyle, transparent, animationType,
 			indicator, indicatorColor, indicatorSize, indicatorStyle, 
 			selectedStyle, selected} = this.props
+		const selectedText = this.getSelectedText()
 
 		return (
 			<View>
 				<TouchableWithoutFeedback onPress = {this.onPress.bind(this)}>
 					<View style = {[styles.selectBox, style]}>
 						<View style={styles.selectBoxContent}>
-							<Text style = {textStyle}>{this.state.defaultText}</Text>
+							<Text style = {textStyle}>{selectedText}</Text>
 							<Indicator direction={indicator} color={indicatorColor} size={indicatorSize} style={indicatorStyle} />
 						</View>
 					</View>
@@ -128,11 +130,6 @@ export default class Select extends Component {
 		})
 	}
 
-	setSelectedText(text){
-		this.setState({
-			defaultText: text
-		})
-	}
 }
 
 var styles = StyleSheet.create({


### PR DESCRIPTION
Currently Select component doesn't update shown text when selected prop changes. This is similar to #27, but that fix only works when selected prop is null.
Also, currently if you want to set an initial value, you should set both selected and defaultText props. I think you should only set selected, and the text to be shown should be taken from the option which has selected value. If there is no option with selected value, or selected is null, then defaultText should be shown.
And I think setSelectedText function is not necessary. The shown text is determined as I described above. If you want to change defaultText, you can do it by changing that prop:
```
render() {
  return (
    <Select defaultText={this.state.defaultSelectText} ... />
  );
}

changeDefaultText(text) {
  this.setState({ defaultSelectText: text });
}
```