### PR TITLE
support orientation change on iOS

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -107,6 +107,7 @@ export default class Select extends Component {
           animationType={animationType}
           visible={this.state.modalVisible}
           onRequestClose={this.onClose.bind(this)}
+          supportedOrientations={['portrait', 'portrait-upside-down', 'landscape', 'landscape-left', 'landscape-right']}
         >
           <TouchableWithoutFeedback onPress={this.onModalPress.bind(this)}>
             <View style={[styles.modalOverlay, backdropStyle]}>
@@ -167,8 +168,6 @@ var styles = StyleSheet.create({
   modalOverlay: {
     flex: 1,
     justifyContent: "center",
-    alignItems: "center",
-    width: window.width,
-    height: window.height
+    alignItems: "center"
   }
 });


### PR DESCRIPTION
- Add `supportedOrientations` prop to <Modal /> 
- Fix black overlay not covering entire device on orientation change on iOS