### PR TITLE
fix(indicator): Indicator is not defined

### DIFF
--- a/lib/indicator.js
+++ b/lib/indicator.js
@@ -10,7 +10,7 @@ import {
   ViewPropTypes
 } from "react-native";
 
-export default (Indicator = function({ direction, size, color, style }) {
+const Indicator = function ({ direction, size, color, style }) {
   const styles = getStyles(size, color);
 
   if (direction === "up") return <View style={[styles.triangle, style]} />;
@@ -18,9 +18,9 @@ export default (Indicator = function({ direction, size, color, style }) {
     return <View style={[styles.triangle, styles.triangleDown, style]} />;
 
   return null;
-});
+};
 
-const getStyles = function(size, color) {
+const getStyles = function (size, color) {
   return StyleSheet.create({
     triangle: {
       width: 0,
@@ -46,3 +46,5 @@ Indicator.propTypes = {
   color: PropTypes.string.isRequired,
   style: ViewPropTypes.style
 };
+
+export default Indicator;


### PR DESCRIPTION
sorry @gs-akhan , i use babel to import all the js file. 
and you know, 

```javascript
Uncaught ReferenceError: Indicator is not defined
    at eval (webpack:///./src/Fuck.js?:1)
    at Object../src/Fuck.js (bundle.js:13126)
    at __webpack_require__ (bundle.js:710)
    at fn (bundle.js:95)
    at eval (webpack:///./src/App.js?:1)
    at Object../src/App.js (bundle.js:13114)
    at __webpack_require__ (bundle.js:710)
    at fn (bundle.js:95)
    at eval (webpack:///./index.web.js?:1)
    at Object../index.web.js (bundle.js:775)
```

i think your code is very good, but i think write it on more common format, the package is better.