### PR TITLE
Prevent line-break in select

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -94,7 +94,7 @@ export default class Select extends Component {
         <TouchableWithoutFeedback onPress={this.onPress.bind(this)}>
           <View style={[styles.selectBox, style]}>
             <View style={styles.selectBoxContent}>
-              <Text style={textStyle}>{this.state.defaultText}</Text>
+              <Text style={textStyle} numberOfLines={1} ellipsizeMode="tail">{this.state.defaultText}</Text>
               {indicatorIcon ?
               indicatorIcon
               :


### PR DESCRIPTION
The Select component does not seem made to handle multiple lines of text. By convention drop-down elements also don't wrap text.